### PR TITLE
Improve bash hashbang

### DIFF
--- a/run-go-fmt.sh
+++ b/run-go-fmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Capture and print stdout, since gofmt doesn't use proper exit codes
 #

--- a/run-go-lint.sh
+++ b/run-go-lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Capture and print stdout/stderr, since golint doesn't use proper exit codes
 #

--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 for file in "$@"; do
     go vet $file

--- a/run-gometalinter.sh
+++ b/run-gometalinter.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env bash
 exec gometalinter --config gometalinter.json ./...


### PR DESCRIPTION
Some linux distros (ex. Nixos) and some related operating systems (ex. FreeBSD) do not have `/bin/bash` while they do have `/usr/bin/env`. This change allows these commit hooks to be used on those systems.