### PR TITLE
Run `go tool vet` against single files instead of `go vet`

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -e
 for file in "$@"; do
-    go vet $file
+    go tool vet $file
 done


### PR DESCRIPTION
The `go vet` command is intended to be run against packages, not single files. With the release of Go 1.10, this causes problems when variables & functions are declared in files in a package other than the one being checked.

This issue explains in more detail: https://github.com/golang/go/issues/23916.

An example from that issue:
```
$ go vet other_file.go             
# command-line-arguments
./other_file.go:6:5: undefined: value
$ go tool vet other_file.go 
$ go version               
go version go1.10 darwin/amd64
```
https://github.com/carterjones/vetissue