### PR TITLE
Add explicit exit if any of the golint runs return non-zero.

### DIFF
--- a/run-go-lint.sh
+++ b/run-go-lint.sh
@@ -2,10 +2,17 @@
 #
 # Capture and print stdout/stderr, since golint doesn't use proper exit codes
 #
-set -e
+failed=false
 
 exec 5>&1
 for file in "$@"; do
     output="$(golint "$file" 2>&1 | tee /dev/fd/5)"
-    [[ -z "$output" ]]
+    if [[ -z "$output" ]]; then
+        failed=true
+    fi
 done
+
+
+if [[ $failed == "true" ]]; then
+    exit 1
+fi


### PR DESCRIPTION
I ran into an issue where the order that files were passed to `run-go-lint.sh` determined if the exit code was set properly. From what I can tell from a little research, relying on `set -e` within a loop either doesn't work or only sometimes works. I replaced it with a local variable and some explicit checks.

I've tested and verified that the script's exit code is now properly set, regardless of the order files are passed to the script.