### PR TITLE
Use -set_exit_status instead of capturing output. Fixes #10.

### DIFF
--- a/run-go-lint.sh
+++ b/run-go-lint.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
-#
-# Capture and print stdout/stderr, since golint doesn't use proper exit codes
-#
+
 failed=false
 
-exec 5>&1
 for file in "$@"; do
-    output="$(golint "$file" 2>&1 | tee /dev/fd/5)"
-    if [[ -z "$output" ]]; then
+    # redirect stderr so that violations and summaries are properly interleaved.
+    if ! golint -set_exit_status "$file" 2>&1
+    then
         failed=true
     fi
 done
-
 
 if [[ $failed == "true" ]]; then
     exit 1


### PR DESCRIPTION
After setting up another machine, I was able to reproduce a problem stemming from the change made by #9, where files were failing lint with no other output. This was also reported in #10. I can't explain this other than perhaps the behavior of golint changed slightly at some point.

Fortunately, `golint` now supports an `set_exit_status` option that will exit with a status of 1 if there were lint warnings. I've modified `run_go_lint.sh` to use this mechanism, which hopefully is more foolproof.

If this patch is merged, could you please release a new version with the fix? Thanks!