### PR TITLE
Switch from `pcre` to `pygrep`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,8 +26,8 @@
 -   id: 'no-go-testing'
     name: "Check files aren't using gos' testing package"
     entry: 'testing\.T'
-    files: 'test_\.go$'
-    language: 'pcre'
+    files: 'test_.*\.go$'
+    language: 'pygrep'
     description: >
       Checks that no files are using `testing.T`, if you want developers to use
       a different testing framework


### PR DESCRIPTION
The [`pygrep`](https://pre-commit.com/#pygrep) language was added in `pre-commit` 1.2.0 as a replacement for `pcre` (which is scheduled for removal in pre-commit 2.x).

In this case, it is a drop-in replacement

Resolves #8