### PR TITLE
Added go-critic to the list of possible linters

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -43,3 +43,9 @@
     files: '\.go$'
     language: 'script'
     description: "Runs `golangci-lint`, requires https://github.com/golangci/golangci-lint"
+-   id: go-critic
+    name: 'go-critic'
+    entry: run-go-critic.sh
+    files: '\.go$'
+    language: 'script'
+    description: "Runs `go-critic`, requires https://github.com/go-critic/go-critic"

--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ Add this to your `.pre-commit-config.yaml`
 - `gometalinter` - run `gometalinter --config gometalinter.json ./...`
 - `golangci-lint` - run `golangci-lint run ./...`, requires
   [golangci-lint](https://github.com/golangci/golangci-lint)
+- `go-critic` - run `gocritic check-project .`, requires [go-critic](https://github.com/go-critic/go-critic)

--- a/run-go-critic.sh
+++ b/run-go-critic.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec gocritic check-project .


### PR DESCRIPTION
Hello,

I added [go-critic](https://github.com/go-critic/go-critic), another nice linter, to the list of possible linters. Go-critic works differently than `gometalinter` or `golangci-lint`, it proposes another kind of checks.

Hope, you'll like it :) 