### PR TITLE
Adds a hook for go build

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,9 +1,3 @@
--   id: go-build
-    name: 'go build'
-    entry: run-go-build.sh
-    files: '\.go$'
-    language: 'script'
-    description: "Runs `go build`, requires golang"
 -   id: go-fmt
     name: 'go fmt'
     entry: run-go-fmt.sh
@@ -61,3 +55,9 @@
     files: '\.go$'
     language: 'script'
     description: "Runs `go test`"
+-   id: go-build
+    name: 'go-build'
+    entry: run-go-build.sh
+    files: '\.go$'
+    language: 'script'
+    description: "Runs `go build`, requires golang"    

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+-   id: go-build
+    name: 'go build'
+    entry: run-go-build.sh
+    files: '\.go$'
+    language: 'script'
+    description: "Runs `go build`, requires golang"
 -   id: go-fmt
     name: 'go fmt'
     entry: run-go-fmt.sh

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Add this to your `.pre-commit-config.yaml`
   [golangci-lint](https://github.com/golangci/golangci-lint)
 - `go-critic` - run `gocritic check-project .`, requires [go-critic](https://github.com/go-critic/go-critic)
 - `go-unit-tests` - run `go test -tags=unit -timeout 30s -short -v`
-- `go-build` - Runs `go build`, requires golang
+- `go-build` - run `go build`, requires golang

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Add this to your `.pre-commit-config.yaml`
         - id: golangci-lint
         - id: go-critic
         - id: go-unit-tests
+        - id: go-build
 
 ### Available hooks
 
@@ -35,3 +36,4 @@ Add this to your `.pre-commit-config.yaml`
   [golangci-lint](https://github.com/golangci/golangci-lint)
 - `go-critic` - run `gocritic check-project .`, requires [go-critic](https://github.com/go-critic/go-critic)
 - `go-unit-tests` - run `go test -tags=unit -timeout 30s -short -v`
+- `go-build` - Runs `go build`, requires golang

--- a/run-go-build.sh
+++ b/run-go-build.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+exec go build


### PR DESCRIPTION
This PR adds a hook for `go build` so that people can test a binary builds before they commit it. I appreciate this isn't something most people would need but it'd be handy to have for those of us that do need it.