### PR TITLE
(fix) case of multiple go files in one directory

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
-for file in "$@"; do
-    go vet $file
+pkg=$(go list)
+for dir in $(echo $@|xargs -n1 dirname|sort -u); do
+  go vet $pkg/$dir
 done


### PR DESCRIPTION
Hi! guys,

The `go vet` needs information about go packages.
So it is not the path to the go files.

before, got errors:
```
$ go vet dir/file.go
dir/file.go:26:10: undefined: FunctionInOutOfThisFile
...
```

after:
```
$ go vet $(go list)/dir
```

Thanks!