### PR TITLE
golangci-lint: fix invocation, skip vendor/, add --fix --fast --new

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -40,8 +40,9 @@
 -   id: golangci-lint
     name: 'golangci-lint'
     entry: run-golangci-lint.sh
-    files: '\.go$'
+    types: [go]
     language: 'script'
+    pass_filenames: false
     description: "Runs `golangci-lint`, requires https://github.com/golangci/golangci-lint"
 -   id: go-critic
     name: 'go-critic'

--- a/run-golangci-lint.sh
+++ b/run-golangci-lint.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
-exec golangci-lint run ./...
+#!/bin/sh
+exec golangci-lint run "$@"


### PR DESCRIPTION
rather than running golangci-lint across the enire codebase at commit
time, only run it on new patches (--new), since despite being fast
it's still an expensive operation. We also only turn on linters in the
fast preset for this reason (--fast). Also, since we're running at
commit time, try to fix issues we find, if the linter supports it
(--fix). The vendor directory also ought not to be touched, if it
exists, so we explicitly skip it.