### PR TITLE
Add recursive files in go-build hook

### DIFF
--- a/run-go-build.sh
+++ b/run-go-build.sh
@@ -1,2 +1,3 @@
 #!/usr/bin/env bash
-exec go build
+FILES=$(go list ./...  | grep -v /vendor/)
+exec go build $FILES


### PR DESCRIPTION
 If the tree is structured with folders and has no .go files in the source directory it will generate the following error:
`can't load package: package <current_path>: no Go files in <current_path>`

This PR allows compiling `.go` files in the project that are not in the current directory.