### PR TITLE
fix: unwrap parameters for golangci-lint

### DIFF
--- a/run-golangci-lint.sh
+++ b/run-golangci-lint.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec golangci-lint run "$@"
+exec golangci-lint run $@


### PR DESCRIPTION
Wrapping of parameters make it impossible to write config like this:

```
- repo: https://github.com/dnephin/pre-commit-golang
  rev: v0.3.5
  hooks:
    - id: golangci-lint
      args: [-c .ci/golangci-lint.yaml]
```