### PR TITLE
Use `#!/usr/bin/env x` instead of `#!/bin/x` for compatibility with Windows

### DIFF
--- a/run-go-cyclo.sh
+++ b/run-go-cyclo.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ $# -eq 0 ]; then
     echo "No arguments supplied"

--- a/run-golangci-lint.sh
+++ b/run-golangci-lint.sh
@@ -1,2 +1,2 @@
-#!/bin/sh
+#!/usr/bin/env sh
 exec golangci-lint run "$@"


### PR DESCRIPTION
It seems these are the only scripts in the repo to not use `#!/usr/bin/env x`

Fixes #54 & #55