### PR TITLE
feat: add go-mod-vendor hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -81,3 +81,9 @@
     files: '\.go$'
     language: 'script'
     description: "Runs `go mod tidy -v`, requires golang"
+-   id: go-mod-vendor
+    name: 'go-mod-vendor'
+    entry: run-go-mod-vendor.sh
+    files: '\.go$'
+    language: 'script'
+    description: "Runs `go mod vendor`, requires golang"

--- a/README.md
+++ b/README.md
@@ -44,3 +44,4 @@ Add this to your `.pre-commit-config.yaml`
 - `go-unit-tests` - run `go test -tags=unit -timeout 30s -short -v`
 - `go-build` - run `go build`, requires golang
 - `go-mod-tidy` - run `go mod tidy -v`, requires golang
+- `go-mod-vendor` - run `go mod vendor`, requires golang

--- a/run-go-mod-vendor.sh
+++ b/run-go-mod-vendor.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+go mod vendor
+git diff --exit-code vendor &> /dev/null
+
+if [ $? -eq 1 ]; then
+    echo "vendor dir differs, please re-add it to your commit"
+
+    exit 1
+fi


### PR DESCRIPTION
* Add a hook that runs `go mod vendor` to ensure that vendored
dependencies are up-to-date