### PR TITLE
Using simpler oneliner for go vet

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,6 +1,3 @@
 #!/usr/bin/env bash
 set -e
-pkg=$(go list)
-for dir in $(echo $@|xargs -n1 dirname|sort -u); do
-  go vet $pkg/$dir
-done
+go vet ./...


### PR DESCRIPTION
The go vet check is failing in [this PR](https://github.com/kedacore/keda/pull/1283) (the logs are [here](https://github.com/kedacore/keda/pull/1283/checks?check_run_id=1311027035)). I'm not sure what's going on, but modern `go vet ./...` will run through all files in the repo. this is suboptimal, but it's not extremely slow in many cases. perhaps there should be two checks? just an idea, not sure if it's necessary