### PR TITLE
Don't suggest a mutable reference to `rev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ golang hooks for http://pre-commit.com/
 Add this to your `.pre-commit-config.yaml`
 
     - repo: git://github.com/dnephin/pre-commit-golang
-      rev: master
+      rev: <VERSION> # Get the latest from: https://github.com/dnephin/pre-commit-golang/releases
       hooks:
         - id: go-fmt
         - id: go-vet


### PR DESCRIPTION
`pre-commit` don't recommend to use a mutable reference to `rev` and now shows a warning when `rev` is a mutable reference.
Ref: https://github.com/pre-commit/pre-commit/pull/1715