### PR TITLE
add -o pipefail to gofmt and goimports scripts

### DIFF
--- a/run-go-fmt.sh
+++ b/run-go-fmt.sh
@@ -2,7 +2,7 @@
 #
 # Capture and print stdout, since gofmt doesn't use proper exit codes
 #
-set -e
+set -e -o pipefail
 
 exec 5>&1
 output="$(gofmt -l -w "$@" | tee /dev/fd/5)"

--- a/run-go-imports.sh
+++ b/run-go-imports.sh
@@ -2,7 +2,7 @@
 #
 # Capture and print stdout, since goimports doesn't use proper exit codes
 #
-set -e
+set -e -o pipefail
 
 exec 5>&1
 output="$(goimports -l -w "$@" | tee /dev/fd/5)"


### PR DESCRIPTION
This avoids silent errors during pre-commit runs (such as when goimports is not installed).