### PR TITLE
Support for go test arguments

### DIFF
--- a/run-go-unit-tests.sh
+++ b/run-go-unit-tests.sh
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 FILES=$(go list ./...  | grep -v /vendor/)
 
-go test -tags=unit -timeout 30s -short -v ${FILES}
+ARGS=""
+
+for arg in "$@"; do
+  [[ $arg == -* ]] && ARGS="${ARGS} $arg"
+done
+
+[ -z "$ARGS" ] && ARGS="-timeout=30s"
+
+go test -tags=unit ${ARGS} -short -v ${FILES}
 
 returncode=$?
 if [ $returncode -ne 0 ]; then


### PR DESCRIPTION
Adding basic support for passing arguments to the `go-unit-tests` hook. Proposed approach is to simply iterate over the script arguments, and keep those that start with at least one `-`.  Initial inspiration for this was adding the ability to override the timeout argument. Current implementation will default to `-timeout=30s` as argument. If arguments are added, then the default timeout needs to be explicitly passed as an argument.