### PR TITLE
fix: support GO111MODULE packages without go files in root

### DIFF
--- a/run-go-vet.sh
+++ b/run-go-vet.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
-set -e
-pkg=$(go list)
-for dir in $(echo $@|xargs -n1 dirname|sort -u); do
-  go vet $pkg/$dir
+set -eu
+if [[ -f "go.mod" ]]; then
+   pkg=$(go list -m)
+else
+   pkg=$(go list)
+fi
+ret=0
+for dir in $(echo "$@"|xargs -n1 dirname|sort -u); do
+   go vet "$pkg/$dir" || ret=$?
 done
+exit $ret


### PR DESCRIPTION
Some packages don't have any go files in the root directory, for
example, those following https://github.com/golang-standards/project-layout

In the case of a GO111MODULE package with go.mod in place, we can just
use "go list -m" and this will return the package name even without
any go files in the project root.

I've also updated the script to report all files that fail "go vet" in
a single run instead of exiting after finding the first error.

This is a fix for issue #30.