### PR TITLE
Update README with a deprecation notice for `golang/go-lint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add this to your `.pre-commit-config.yaml`
 
 - `go-fmt` - Runs `gofmt`, requires golang
 - `go-vet` - Runs `go vet`, requires golang
-- `go-lint` - Runs `golint`, requires https://github.com/golang/lint
+- `go-lint` - Runs `golint`, requires https://github.com/golang/lint but is unmaintained & deprecated in favour of [`golangci-lint`](https://github.com/golangci/golangci-lint)
 - `go-imports` - Runs `goimports`, requires golang.org/x/tools/cmd/goimports
 - `go-cyclo` - Runs `gocyclo`, require https://github.com/fzipp/gocyclo
 - `validate-toml` - Runs `tomlv`, requires


### PR DESCRIPTION
The `golang/go-lint` project isn't actively maintained right now. And the authors recommends using other tools like [`golangci/golangci-lint](https://github.com/golangci/golangci-lint). As such this PR updates the README with a proper deprecation notice.

Closes #89 