### PR TITLE
Fix go-generate for multiple directories

### DIFF
--- a/run-go-generate.sh
+++ b/run-go-generate.sh
@@ -1,2 +1,5 @@
 #!/usr/bin/env bash
-exec go generate "$@"
+
+set -eu -o pipefail
+
+echo "$@" | xargs -n1 go generate


### PR DESCRIPTION
If you change files in multiple directories, `go generate` will return an error.
```
named files must all be in one directory; have foo and bar
```

Issue #76 