### PR TITLE
Fix go-unit-test script falsely succeeding if go list ./... fails

### DIFF
--- a/run-go-unit-tests.sh
+++ b/run-go-unit-tests.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
-FILES=$(go list ./...  | grep -v /vendor/)
 
-go test -tags=unit -timeout 30s -short -v ${FILES}
-
-returncode=$?
-if [ $returncode -ne 0 ]; then
+fail() {
   echo "unit tests failed"
   exit 1
-fi
+}
+
+FILES=$(go list ./... | grep -v /vendor/) || fail
+go test -tags=unit -timeout 30s -short -v ${FILES} || fail


### PR DESCRIPTION
Hi, this PR fixes issue https://github.com/dnephin/pre-commit-golang/issues/94 that I reported, It does so by ensuring that the `FILES=$(go list ./... | grep -v /vendor/)` command succeeds before running the tests. The `|| fail` will catch any non-zero return statuses and exit with error code 1.