### PR TITLE
Set `go-mod-tidy` hook as `always_run: true`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -84,6 +84,7 @@
 -   id: go-mod-tidy
     name: 'go-mod-tidy'
     entry: run-go-mod-tidy.sh
+    always_run: true
     pass_filenames: false
     language: 'script'
     description: "Runs `go mod tidy -v`, requires golang"


### PR DESCRIPTION
While it could be that we only need to run `go mod tidy` only after `\.go$` files modifications, currently it runs for `''`, which I assume to be the catch-all "if any file is modified, run this hook".

Let's make this more explicit by setting `always_run: true`

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>