### PR TITLE
feat: add run-tokolint

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,4 @@ Add this to your `.pre-commit-config.yaml`
 - `go-build` - run `go build`, requires golang
 - `go-mod-tidy` - run `go mod tidy -v`, requires golang
 - `go-mod-vendor` - run `go mod vendor`, requires golang
+- `tokolint` - run `tokolint`, requires [tokolint](https://github.com/tokopedia/tokolint)

--- a/run-go-unit-tests.sh
+++ b/run-go-unit-tests.sh
@@ -6,4 +6,4 @@ fail() {
 }
 
 FILES=$(go list ./... | grep -v /vendor/) || fail
-go test -tags=unit -timeout 30s -short -v ${FILES} || fail
+go test -cover -count=1 -race -v ${FILES} || fail

--- a/run-tokolint.sh
+++ b/run-tokolint.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+function get_root_branch() {
+    git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'
+}
+
+function cleanup() {
+    rm a.patch
+}
+
+set -eu -o pipefail
+
+if ! command -v tokolint-cli &> /dev/null ; then
+    echo "tokolint not installed or available in the PATH" >&2
+    echo "please check https://github.com/tokopedia/tokolint" >&2
+    exit 1
+fi
+
+if ! command -v golangci-lint &> /dev/null ; then
+    echo "tokolint installation is corrupted" >&2
+    echo "please re-install https://github.com/tokopedia/tokolint" >&2
+    exit 1
+fi
+
+root_branch=$(get_root_branch)
+git --no-pager diff --output=a.patch origin/"$root_branch"
+
+trap cleanup EXIT
+
+golangci-lint run --new-from-patch=a.patch "$@"


### PR DESCRIPTION
## Overview

This pull request adds a new pre-committer `run-tokolint`. By default, it will only lint changes in the current branch. 